### PR TITLE
Add plugin activation to configuration file

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,6 @@
 {
-  "plansDirectory": "docs/plans"
+  "plansDirectory": "docs/plans",
+  "enabledPlugins": {
+    "everything-claude-code@everything-claude-code": true
+  }
 }


### PR DESCRIPTION
Include a new section in the configuration file to enable specific plugins.