### PR TITLE
Add transaction handling for history management in project and test suite services

### DIFF
--- a/apps/api/src/__tests__/unit/project.repository.test.ts
+++ b/apps/api/src/__tests__/unit/project.repository.test.ts
@@ -4,7 +4,6 @@ import { ProjectRepository } from '../../repositories/project.repository.js';
 // Prisma のモック（vi.hoistedでホイスティング問題を回避）
 const mockPrismaProject = vi.hoisted(() => ({
   findFirst: vi.fn(),
-  update: vi.fn(),
 }));
 
 const mockPrismaProjectHistory = vi.hoisted(() => ({
@@ -127,127 +126,6 @@ describe('ProjectRepository', () => {
       const result = await repository.findDeletedById('active-project');
 
       expect(result).toBeNull();
-    });
-  });
-
-  describe('update', () => {
-    it('nameを更新できる', async () => {
-      const mockProject = {
-        id: 'project-1',
-        name: 'Updated Name',
-      };
-      mockPrismaProject.update.mockResolvedValue(mockProject);
-
-      const result = await repository.update('project-1', { name: 'Updated Name' });
-
-      expect(mockPrismaProject.update).toHaveBeenCalledWith({
-        where: { id: 'project-1' },
-        data: { name: 'Updated Name' },
-      });
-      expect(result).toEqual(mockProject);
-    });
-
-    it('descriptionを更新できる', async () => {
-      const mockProject = {
-        id: 'project-1',
-        description: 'New description',
-      };
-      mockPrismaProject.update.mockResolvedValue(mockProject);
-
-      const result = await repository.update('project-1', { description: 'New description' });
-
-      expect(mockPrismaProject.update).toHaveBeenCalledWith({
-        where: { id: 'project-1' },
-        data: { description: 'New description' },
-      });
-      expect(result).toEqual(mockProject);
-    });
-
-    it('descriptionをnullに設定できる', async () => {
-      const mockProject = {
-        id: 'project-1',
-        description: null,
-      };
-      mockPrismaProject.update.mockResolvedValue(mockProject);
-
-      const result = await repository.update('project-1', { description: null });
-
-      expect(mockPrismaProject.update).toHaveBeenCalledWith({
-        where: { id: 'project-1' },
-        data: { description: null },
-      });
-      expect(result).toEqual(mockProject);
-    });
-
-    it('nameとdescriptionを同時に更新できる', async () => {
-      const mockProject = {
-        id: 'project-1',
-        name: 'New Name',
-        description: 'New description',
-      };
-      mockPrismaProject.update.mockResolvedValue(mockProject);
-
-      const result = await repository.update('project-1', {
-        name: 'New Name',
-        description: 'New description',
-      });
-
-      expect(mockPrismaProject.update).toHaveBeenCalledWith({
-        where: { id: 'project-1' },
-        data: {
-          name: 'New Name',
-          description: 'New description',
-        },
-      });
-      expect(result).toEqual(mockProject);
-    });
-  });
-
-  describe('softDelete', () => {
-    it('プロジェクトを論理削除できる', async () => {
-      const mockProject = {
-        id: 'project-1',
-        deletedAt: new Date(),
-      };
-      mockPrismaProject.update.mockResolvedValue(mockProject);
-
-      const result = await repository.softDelete('project-1');
-
-      expect(mockPrismaProject.update).toHaveBeenCalledWith({
-        where: { id: 'project-1' },
-        data: { deletedAt: expect.any(Date) },
-      });
-      expect(result).toEqual(mockProject);
-      expect(result.deletedAt).not.toBeNull();
-    });
-  });
-
-  describe('restore', () => {
-    it('削除済みプロジェクトを復元できる', async () => {
-      const mockProject = {
-        id: 'project-1',
-        name: 'Restored Project',
-        deletedAt: null,
-        organization: {
-          id: 'org-1',
-          name: 'Test Organization',
-        },
-      };
-      mockPrismaProject.update.mockResolvedValue(mockProject);
-
-      const result = await repository.restore('project-1');
-
-      expect(mockPrismaProject.update).toHaveBeenCalledWith({
-        where: { id: 'project-1' },
-        data: { deletedAt: null },
-        include: {
-          organization: {
-            select: { id: true, name: true },
-          },
-        },
-      });
-      expect(result).toEqual(mockProject);
-      expect(result.deletedAt).toBeNull();
     });
   });
 

--- a/apps/api/src/__tests__/unit/project.service.history.test.ts
+++ b/apps/api/src/__tests__/unit/project.service.history.test.ts
@@ -11,9 +11,6 @@ const mockProjectRepo = vi.hoisted(() => ({
   createHistory: vi.fn(),
   getHistories: vi.fn(),
   countHistories: vi.fn(),
-  restore: vi.fn(),
-  update: vi.fn(),
-  softDelete: vi.fn(),
 }));
 
 vi.mock('../../repositories/project.repository.js', () => ({
@@ -395,6 +392,48 @@ describe('ProjectService - History & Restore', () => {
           },
         },
       });
+    });
+  });
+
+  // ============================================================
+  // トランザクションロールバック
+  // ============================================================
+  describe('トランザクションロールバック', () => {
+    it('update中に履歴作成が失敗した場合、更新もロールバックされる', async () => {
+      mockProjectRepo.findById.mockResolvedValue(mockProject);
+      mockPrisma.project.update.mockResolvedValue({ ...mockProject, name: 'Updated' });
+      mockPrisma.projectHistory.create.mockRejectedValue(new Error('DB error'));
+      mockPrisma.$transaction.mockImplementation(async (fn: unknown) => {
+        return (fn as (tx: typeof mockPrisma) => unknown)(mockPrisma);
+      });
+
+      await expect(service.update('project-1', { name: 'Updated' }, 'user-1'))
+        .rejects.toThrow('DB error');
+    });
+
+    it('softDelete中に履歴作成が失敗した場合、削除もロールバックされる', async () => {
+      mockProjectRepo.findById.mockResolvedValue(mockProject);
+      mockPrisma.project.update.mockResolvedValue({ ...mockProject, deletedAt: new Date() });
+      mockPrisma.projectHistory.create.mockRejectedValue(new Error('DB error'));
+      mockPrisma.$transaction.mockImplementation(async (fn: unknown) => {
+        return (fn as (tx: typeof mockPrisma) => unknown)(mockPrisma);
+      });
+
+      await expect(service.softDelete('project-1', 'user-1'))
+        .rejects.toThrow('DB error');
+    });
+
+    it('restore中に履歴作成が失敗した場合、復元もロールバックされる', async () => {
+      const deletedRecently = { ...mockDeletedProject, deletedAt: new Date() };
+      mockProjectRepo.findDeletedById.mockResolvedValue(deletedRecently);
+      mockPrisma.project.update.mockResolvedValue({ ...mockProject, deletedAt: null });
+      mockPrisma.projectHistory.create.mockRejectedValue(new Error('DB error'));
+      mockPrisma.$transaction.mockImplementation(async (fn: unknown) => {
+        return (fn as (tx: typeof mockPrisma) => unknown)(mockPrisma);
+      });
+
+      await expect(service.restore('project-1', 'user-1'))
+        .rejects.toThrow('DB error');
     });
   });
 });

--- a/apps/api/src/__tests__/unit/test-suite.repository.crud.test.ts
+++ b/apps/api/src/__tests__/unit/test-suite.repository.crud.test.ts
@@ -61,49 +61,6 @@ describe('TestSuiteRepository（コアCRUD）', () => {
     });
   });
 
-  describe('update', () => {
-    it('テストスイートを更新できる', async () => {
-      const updated = { id: TEST_SUITE_ID, name: '更新名' };
-      mockPrismaTestSuite.update.mockResolvedValue(updated);
-
-      const result = await repository.update(TEST_SUITE_ID, { name: '更新名' });
-
-      expect(result).toEqual(updated);
-      expect(mockPrismaTestSuite.update).toHaveBeenCalledWith({
-        where: { id: TEST_SUITE_ID },
-        data: { name: '更新名' },
-      });
-    });
-
-    it('複数フィールドを同時に更新できる', async () => {
-      mockPrismaTestSuite.update.mockResolvedValue({ id: TEST_SUITE_ID });
-
-      await repository.update(TEST_SUITE_ID, {
-        name: '新名前',
-        description: '新説明',
-        status: 'ACTIVE',
-      });
-
-      expect(mockPrismaTestSuite.update).toHaveBeenCalledWith({
-        where: { id: TEST_SUITE_ID },
-        data: { name: '新名前', description: '新説明', status: 'ACTIVE' },
-      });
-    });
-  });
-
-  describe('softDelete', () => {
-    it('deletedAtを設定して論理削除する', async () => {
-      mockPrismaTestSuite.update.mockResolvedValue({ id: TEST_SUITE_ID });
-
-      await repository.softDelete(TEST_SUITE_ID);
-
-      expect(mockPrismaTestSuite.update).toHaveBeenCalledWith({
-        where: { id: TEST_SUITE_ID },
-        data: { deletedAt: expect.any(Date) },
-      });
-    });
-  });
-
   describe('suggest', () => {
     it('キーワードなしで候補を取得できる', async () => {
       const mockResults = [{ id: TEST_SUITE_ID, name: 'Suite' }];
@@ -149,19 +106,6 @@ describe('TestSuiteRepository（コアCRUD）', () => {
       expect(mockPrismaTestSuite.findFirst).toHaveBeenCalledWith({
         where: { id: TEST_SUITE_ID, deletedAt: { not: null } },
         include: expect.any(Object),
-      });
-    });
-  });
-
-  describe('restore', () => {
-    it('deletedAtをnullに設定して復元する', async () => {
-      mockPrismaTestSuite.update.mockResolvedValue({ id: TEST_SUITE_ID, deletedAt: null });
-
-      await repository.restore(TEST_SUITE_ID);
-
-      expect(mockPrismaTestSuite.update).toHaveBeenCalledWith({
-        where: { id: TEST_SUITE_ID },
-        data: { deletedAt: null },
       });
     });
   });

--- a/apps/api/src/__tests__/unit/test-suite.service.crud.test.ts
+++ b/apps/api/src/__tests__/unit/test-suite.service.crud.test.ts
@@ -22,8 +22,6 @@ vi.mock('@agentest/db', () => ({
 // TestSuiteRepositoryモック
 const mockTestSuiteRepo = vi.hoisted(() => ({
   findById: vi.fn(),
-  update: vi.fn(),
-  softDelete: vi.fn(),
   suggest: vi.fn(),
   search: vi.fn(),
 }));
@@ -250,6 +248,36 @@ describe('TestSuiteService（コアCRUD）', () => {
       mockTestSuiteRepo.findById.mockResolvedValue(null);
 
       await expect(service.softDelete(TEST_SUITE_ID, TEST_USER_ID)).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe('トランザクションロールバック', () => {
+    beforeEach(() => {
+      mockTestSuiteRepo.findById.mockResolvedValue(createMockTestSuite());
+    });
+
+    it('update中に履歴作成が失敗した場合、エラーが伝播する', async () => {
+      mockPrisma.testSuite.update.mockResolvedValue(createMockTestSuite({ name: '更新名' }));
+      mockPrisma.testSuiteHistory.create.mockRejectedValue(new Error('DB error'));
+      mockPrisma.$transaction.mockImplementation(async (fn: unknown) => {
+        return (fn as (tx: typeof mockPrisma) => unknown)(mockPrisma);
+      });
+
+      await expect(
+        service.update(TEST_SUITE_ID, TEST_USER_ID, { name: '更新名' })
+      ).rejects.toThrow('DB error');
+    });
+
+    it('softDelete中に履歴作成が失敗した場合、エラーが伝播する', async () => {
+      mockPrisma.testSuite.update.mockResolvedValue({ id: TEST_SUITE_ID });
+      mockPrisma.testSuiteHistory.create.mockRejectedValue(new Error('DB error'));
+      mockPrisma.$transaction.mockImplementation(async (fn: unknown) => {
+        return (fn as (tx: typeof mockPrisma) => unknown)(mockPrisma);
+      });
+
+      await expect(
+        service.softDelete(TEST_SUITE_ID, TEST_USER_ID)
+      ).rejects.toThrow('DB error');
     });
   });
 

--- a/apps/api/src/__tests__/unit/test-suite.service.history.test.ts
+++ b/apps/api/src/__tests__/unit/test-suite.service.history.test.ts
@@ -8,7 +8,6 @@ const mockTestSuiteRepo = vi.hoisted(() => ({
   getHistories: vi.fn(),
   getHistoriesGrouped: vi.fn(),
   countHistories: vi.fn(),
-  restore: vi.fn(),
 }));
 
 vi.mock('../../repositories/test-suite.repository.js', () => ({
@@ -24,13 +23,11 @@ const mockPrisma = vi.hoisted(() => ({
   testSuiteHistory: {
     create: vi.fn(),
   },
-  $transaction: vi.fn((operations) => {
-    // 配列の場合は順番に実行
+  $transaction: vi.fn((operations: unknown) => {
     if (Array.isArray(operations)) {
       return Promise.all(operations);
     }
-    // 関数の場合はコールバックとして実行
-    return operations(mockPrisma);
+    return (operations as (tx: typeof mockPrisma) => unknown)(mockPrisma);
   }),
 }));
 

--- a/apps/api/src/repositories/project.repository.ts
+++ b/apps/api/src/repositories/project.repository.ts
@@ -39,41 +39,6 @@ export class ProjectRepository {
   }
 
   /**
-   * プロジェクトを更新
-   */
-  async update(id: string, data: { name?: string; description?: string | null }) {
-    return prisma.project.update({
-      where: { id },
-      data,
-    });
-  }
-
-  /**
-   * プロジェクトを論理削除
-   */
-  async softDelete(id: string) {
-    return prisma.project.update({
-      where: { id },
-      data: { deletedAt: new Date() },
-    });
-  }
-
-  /**
-   * プロジェクトを復元
-   */
-  async restore(id: string) {
-    return prisma.project.update({
-      where: { id },
-      data: { deletedAt: null },
-      include: {
-        organization: {
-          select: { id: true, name: true },
-        },
-      },
-    });
-  }
-
-  /**
    * 履歴を作成
    */
   async createHistory(data: {

--- a/apps/api/src/repositories/test-suite.repository.ts
+++ b/apps/api/src/repositories/test-suite.repository.ts
@@ -150,26 +150,6 @@ export class TestSuiteRepository {
   }
 
   /**
-   * テストスイートを更新
-   */
-  async update(id: string, data: { name?: string; description?: string | null; status?: EntityStatus }) {
-    return prisma.testSuite.update({
-      where: { id },
-      data,
-    });
-  }
-
-  /**
-   * テストスイートを論理削除
-   */
-  async softDelete(id: string) {
-    return prisma.testSuite.update({
-      where: { id },
-      data: { deletedAt: new Date() },
-    });
-  }
-
-  /**
    * 削除済みテストスイートをIDで検索
    */
   async findDeletedById(id: string) {
@@ -189,16 +169,6 @@ export class TestSuiteRepository {
           select: { testCases: true, preconditions: true },
         },
       },
-    });
-  }
-
-  /**
-   * テストスイートを復元（deletedAtをnullに設定）
-   */
-  async restore(id: string) {
-    return prisma.testSuite.update({
-      where: { id },
-      data: { deletedAt: null },
     });
   }
 

--- a/apps/api/src/services/project.service.ts
+++ b/apps/api/src/services/project.service.ts
@@ -500,7 +500,9 @@ export class ProjectService {
   }
 
   /**
-   * 履歴を作成
+   * 単独で履歴を作成（トランザクション外で使用）
+   * 注意: CRUD操作の履歴はそれぞれのメソッド内でトランザクションにより保証されている。
+   * このメソッドは外部から個別に履歴を追加する場合にのみ使用する。
    */
   async createHistory(
     projectId: string,

--- a/apps/api/src/services/test-suite.service.ts
+++ b/apps/api/src/services/test-suite.service.ts
@@ -63,6 +63,7 @@ export class TestSuiteService {
 
   /**
    * テストスイートを作成
+   * 注意: CREATE履歴は作成しない（TestCaseServiceと同様の方針）
    */
   async create(userId: string, data: { projectId: string; name: string; description?: string; status?: EntityStatus }) {
     // プロジェクトの存在確認
@@ -135,8 +136,13 @@ export class TestSuiteService {
       },
     };
 
-    // トランザクションで履歴保存と本体更新を実行
+    // トランザクションで本体更新と履歴保存を実行
     const result = await prisma.$transaction(async (tx) => {
+      const updated = await tx.testSuite.update({
+        where: { id: testSuiteId },
+        data,
+      });
+
       await tx.testSuiteHistory.create({
         data: {
           testSuiteId,
@@ -147,10 +153,7 @@ export class TestSuiteService {
         },
       });
 
-      return tx.testSuite.update({
-        where: { id: testSuiteId },
-        data,
-      });
+      return updated;
     });
 
     // ダッシュボード更新イベント発行
@@ -173,8 +176,13 @@ export class TestSuiteService {
       status: testSuite.status,
     };
 
-    // トランザクションで履歴保存と論理削除を実行
+    // トランザクションで論理削除と履歴保存を実行
     const result = await prisma.$transaction(async (tx) => {
+      const deleted = await tx.testSuite.update({
+        where: { id: testSuiteId },
+        data: { deletedAt: new Date() },
+      });
+
       await tx.testSuiteHistory.create({
         data: {
           testSuiteId,
@@ -185,10 +193,7 @@ export class TestSuiteService {
         },
       });
 
-      return tx.testSuite.update({
-        where: { id: testSuiteId },
-        data: { deletedAt: new Date() },
-      });
+      return deleted;
     });
 
     // ダッシュボード更新イベント発行
@@ -360,8 +365,13 @@ export class TestSuiteService {
       },
     };
 
-    // トランザクションで履歴保存と前提条件更新を実行
+    // トランザクションで前提条件更新と履歴保存を実行
     const result = await prisma.$transaction(async (tx) => {
+      const updated = await tx.testSuitePrecondition.update({
+        where: { id: preconditionId },
+        data: { content: data.content },
+      });
+
       await tx.testSuiteHistory.create({
         data: {
           testSuiteId,
@@ -372,10 +382,7 @@ export class TestSuiteService {
         },
       });
 
-      return tx.testSuitePrecondition.update({
-        where: { id: preconditionId },
-        data: { content: data.content },
-      });
+      return updated;
     });
 
     // テストスイート更新イベント発行（エラー時も処理継続）
@@ -424,17 +431,6 @@ export class TestSuiteService {
 
     // トランザクションで削除と再整列を実行
     await prisma.$transaction(async (tx) => {
-      // 履歴を保存
-      await tx.testSuiteHistory.create({
-        data: {
-          testSuiteId,
-          changedByUserId: userId,
-          changeType: 'UPDATE',
-          snapshot: toJsonSnapshot(snapshot),
-          groupId: options?.groupId,
-        },
-      });
-
       // 前提条件を削除
       await tx.testSuitePrecondition.delete({
         where: { id: preconditionId },
@@ -452,6 +448,17 @@ export class TestSuiteService {
           data: { orderKey: `${i + 1}`.padStart(5, '0') },
         });
       }
+
+      // 履歴を保存
+      await tx.testSuiteHistory.create({
+        data: {
+          testSuiteId,
+          changedByUserId: userId,
+          changeType: 'UPDATE',
+          snapshot: toJsonSnapshot(snapshot),
+          groupId: options?.groupId,
+        },
+      });
     });
 
     // テストスイート更新イベント発行（エラー時も処理継続）
@@ -517,8 +524,18 @@ export class TestSuiteService {
       },
     };
 
-    // トランザクションで履歴保存とorderKey更新を実行
+    // トランザクションでorderKey更新と履歴保存を実行
     await prisma.$transaction(async (tx) => {
+      // 各前提条件のorderKeyを更新
+      await Promise.all(
+        preconditionIds.map((id, index) =>
+          tx.testSuitePrecondition.update({
+            where: { id },
+            data: { orderKey: `${index + 1}`.padStart(5, '0') },
+          })
+        )
+      );
+
       // 履歴を保存（並び替え前の状態）
       await tx.testSuiteHistory.create({
         data: {
@@ -529,16 +546,6 @@ export class TestSuiteService {
           groupId: options?.groupId,
         },
       });
-
-      // 各前提条件のorderKeyを更新
-      await Promise.all(
-        preconditionIds.map((id, index) =>
-          tx.testSuitePrecondition.update({
-            where: { id },
-            data: { orderKey: `${index + 1}`.padStart(5, '0') },
-          })
-        )
-      );
     });
 
     // テストスイート更新イベント発行（エラー時も処理継続）
@@ -867,6 +874,12 @@ export class TestSuiteService {
 
     // 復元と履歴保存をトランザクションで実行
     const result = await prisma.$transaction(async (tx) => {
+      // 復元（deletedAtをnullに設定）
+      const restored = await tx.testSuite.update({
+        where: { id: testSuiteId },
+        data: { deletedAt: null },
+      });
+
       // 履歴を保存
       await tx.testSuiteHistory.create({
         data: {
@@ -878,11 +891,7 @@ export class TestSuiteService {
         },
       });
 
-      // 復元（deletedAtをnullに設定）
-      return tx.testSuite.update({
-        where: { id: testSuiteId },
-        data: { deletedAt: null },
-      });
+      return restored;
     });
 
     // ダッシュボード更新イベント発行
@@ -957,6 +966,16 @@ export class TestSuiteService {
 
     // トランザクション実行
     await prisma.$transaction(async (tx) => {
+      // orderKey更新（並列実行）
+      await Promise.all(
+        testCaseIds.map((id, index) =>
+          tx.testCase.update({
+            where: { id },
+            data: { orderKey: `${index + 1}`.padStart(5, '0') },
+          })
+        )
+      );
+
       // 履歴保存
       await tx.testSuiteHistory.create({
         data: {
@@ -967,16 +986,6 @@ export class TestSuiteService {
           groupId: options?.groupId,
         },
       });
-
-      // orderKey更新（並列実行）
-      await Promise.all(
-        testCaseIds.map((id, index) =>
-          tx.testCase.update({
-            where: { id },
-            data: { orderKey: `${index + 1}`.padStart(5, '0') },
-          })
-        )
-      );
     });
 
     // テストスイート更新イベント発行（エラー時も処理継続）


### PR DESCRIPTION
Implement transaction management for update, delete, and restore operations in both project and test suite services, ensuring rollback on history creation failures.