### PR TITLE
Improve E2E tests and add API client functionality

### DIFF
--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -9,9 +9,16 @@ type Fixtures = {
 };
 
 export const test = base.extend<Fixtures>({
-  // WebアプリがVITE_API_URLで直接APIにアクセスするため、
-  // APIリクエストをViteプロキシ経由に書き換えてクッキーが正しく送信されるようにする
   page: async ({ page }, use) => {
+    // Vite HMRのWebSocket接続が常にアクティブなためloadイベントが発火しない場合がある。
+    // デフォルトのwaitUntilをdomcontentloadedに変更してタイムアウトを防止する。
+    const originalGoto = page.goto.bind(page);
+    page.goto = ((url: string, options?: { waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit'; timeout?: number; referer?: string }) => {
+      return originalGoto(url, { waitUntil: 'domcontentloaded', ...options });
+    }) as typeof page.goto;
+
+    // WebアプリがVITE_API_URLで直接APIにアクセスするため、
+    // APIリクエストをViteプロキシ経由に書き換えてクッキーが正しく送信されるようにする
     await page.route(`${API_URL}/**`, (route) => {
       const url = route.request().url().replace(API_URL, WEB_URL);
       route.continue({ url });

--- a/e2e/helpers/api-client.ts
+++ b/e2e/helpers/api-client.ts
@@ -320,6 +320,19 @@ export class TestApiClient {
   // 組織管理
   // =====================
 
+  /**
+   * ログインユーザーの所属組織一覧を取得
+   */
+  async getUserOrganizations() {
+    const meResponse = await this.request.get(`${this.baseUrl}/api/auth/me`);
+    const me = await meResponse.json();
+    const userId = me.user.id;
+    const response = await this.request.get(`${this.baseUrl}/api/users/${userId}/organizations`);
+    return response.json() as Promise<{
+      organizations: Array<{ organization: { id: string; name: string }; role: string }>;
+    }>;
+  }
+
   async createOrganization(data: { name: string; description?: string }) {
     const response = await this.request.post(`${this.baseUrl}/api/organizations`, {
       data,
@@ -424,7 +437,7 @@ export class TestApiClient {
   // =====================
 
   async getUserProfile() {
-    const response = await this.request.get(`${this.baseUrl}/api/users/me`);
+    const response = await this.request.get(`${this.baseUrl}/api/auth/me`);
     return response.json();
   }
 

--- a/e2e/tests/web/login.spec.ts
+++ b/e2e/tests/web/login.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../../fixtures';
 
 // ログインページは認証不要 → storageState を上書き
 test.use({ storageState: { cookies: [], origins: [] } });

--- a/e2e/tests/web/organizations.spec.ts
+++ b/e2e/tests/web/organizations.spec.ts
@@ -14,28 +14,45 @@ test.describe('組織一覧', () => {
 
   test('新規組織を作成できる', async ({ page, apiClient }) => {
     const orgName = `E2E Org ${Date.now()}`;
+    let createdOrgId: string | null = null;
 
-    // 組織一覧ページに遷移
-    await page.goto('/organizations');
+    try {
+      // 組織一覧ページに遷移
+      await page.goto('/organizations');
 
-    // 「組織を作成」ボタンをクリック
-    await page.getByRole('button', { name: '組織を作成' }).click();
+      // 「組織を作成」ボタンをクリック
+      await page.getByRole('button', { name: '組織を作成' }).click();
 
-    // モーダルが表示される
-    await expect(page.getByRole('heading', { name: '組織を作成' })).toBeVisible();
+      // モーダルが表示される
+      await expect(page.getByRole('heading', { name: '組織を作成' })).toBeVisible();
 
-    // 組織名を入力（プレースホルダー「My Organization」で特定）
-    const nameInput = page.getByPlaceholder('My Organization');
-    await nameInput.fill(orgName);
+      // 組織名を入力（プレースホルダー「My Organization」で特定）
+      const nameInput = page.getByPlaceholder('My Organization');
+      await nameInput.fill(orgName);
 
-    // 作成ボタンをクリック
-    await page.getByRole('button', { name: '作成', exact: true }).click();
+      // 作成ボタンをクリック
+      await page.getByRole('button', { name: '作成', exact: true }).click();
 
-    // 組織作成後はダッシュボードにリダイレクトされる
-    // 成功メッセージまたはダッシュボードの見出しが表示される
-    await expect(
-      page.getByText(/作成しました/).or(page.getByRole('heading', { name: '最近のプロジェクト' }))
-    ).toBeVisible({ timeout: 15000 });
+      // 組織作成後はダッシュボードにリダイレクトされる
+      // 成功メッセージまたはダッシュボードの見出しが表示される
+      await expect(
+        page.getByText(/作成しました/).or(page.getByRole('heading', { name: '最近のプロジェクト' }))
+      ).toBeVisible({ timeout: 15000 });
+
+      // 作成した組織のIDをAPIから取得（クリーンアップ用）
+      const orgs = await apiClient.getUserOrganizations();
+      const createdOrg = orgs.organizations.find(
+        (o) => o.organization.name === orgName,
+      );
+      if (createdOrg) {
+        createdOrgId = createdOrg.organization.id;
+      }
+    } finally {
+      // クリーンアップ: 作成した組織を削除
+      if (createdOrgId) {
+        await apiClient.deleteOrganization(createdOrgId);
+      }
+    }
   });
 
   test('組織を検索できる', async ({ page }) => {

--- a/e2e/tests/web/projects.spec.ts
+++ b/e2e/tests/web/projects.spec.ts
@@ -1,5 +1,16 @@
 import { test, expect } from '../../fixtures';
 
+// シードデータのDemo Projectは「Demo Organization」に属している
+const DEMO_ORG_NAME = 'Demo Organization';
+
+/**
+ * 組織フィルターを選択するヘルパー
+ */
+async function selectOrganizationFilter(page: import('@playwright/test').Page, orgName: string) {
+  const filterSelect = page.locator('select').filter({ hasText: '個人プロジェクト' });
+  await filterSelect.selectOption({ label: orgName });
+}
+
 test.describe('プロジェクト一覧', () => {
   test('プロジェクト一覧ページが表示される', async ({ page }) => {
     await page.goto('/projects');
@@ -14,12 +25,21 @@ test.describe('プロジェクト一覧', () => {
   test('Demoプロジェクトが一覧に表示される', async ({ page }) => {
     await page.goto('/projects');
 
+    // Demo ProjectはDemo Organizationに属しているため、組織フィルターを変更
+    await selectOrganizationFilter(page, DEMO_ORG_NAME);
+
     // シードデータの Demo Project が表示される（h3要素を指定）
-    await expect(page.getByRole('heading', { name: 'Demo Project' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Demo Project' })).toBeVisible({ timeout: 10000 });
   });
 
   test('プロジェクトを検索できる', async ({ page }) => {
     await page.goto('/projects');
+
+    // Demo Organizationのプロジェクトを表示
+    await selectOrganizationFilter(page, DEMO_ORG_NAME);
+
+    // Demo Projectが表示されるのを待つ
+    await expect(page.getByRole('heading', { name: 'Demo Project' })).toBeVisible({ timeout: 10000 });
 
     // 検索フィールドに入力
     await page.getByPlaceholder('プロジェクトを検索...').fill('Demo');
@@ -30,6 +50,12 @@ test.describe('プロジェクト一覧', () => {
 
   test('プロジェクト詳細画面に遷移できる', async ({ page }) => {
     await page.goto('/projects');
+
+    // Demo Organizationのプロジェクトを表示
+    await selectOrganizationFilter(page, DEMO_ORG_NAME);
+
+    // Demo Projectが表示されるのを待つ
+    await expect(page.getByRole('heading', { name: 'Demo Project' })).toBeVisible({ timeout: 10000 });
 
     // Demo Project をクリック（h3要素）
     await page.getByRole('heading', { name: 'Demo Project' }).click();

--- a/e2e/tests/web/test-cases.spec.ts
+++ b/e2e/tests/web/test-cases.spec.ts
@@ -394,15 +394,15 @@ test.describe('テストケースCRUD', () => {
       if (match && match[1] !== testCase.testCase.id) {
         copiedTestCaseId = match[1];
       }
-
-      // コピーが成功したことを確認（モーダルが閉じた = エラーなく完了）
-      // 注：コピー後のナビゲーション動作はアプリケーションの実装に依存するため、
-      //     ここではモーダルが正常に閉じることをもってコピー成功とみなす
     } finally {
-      // クリーンアップ
-      await apiClient.deleteTestCase(DEMO_PROJECT_ID, DEMO_TEST_SUITE_ID, testCase.testCase.id);
+      // クリーンアップ（タイムアウト後はブラウザが閉じている可能性があるためエラーを無視）
+      try {
+        await apiClient.deleteTestCase(DEMO_PROJECT_ID, DEMO_TEST_SUITE_ID, testCase.testCase.id);
+      } catch { /* 削除済みまたはコンテキスト閉鎖 */ }
       if (copiedTestCaseId) {
-        await apiClient.deleteTestCase(DEMO_PROJECT_ID, DEMO_TEST_SUITE_ID, copiedTestCaseId);
+        try {
+          await apiClient.deleteTestCase(DEMO_PROJECT_ID, DEMO_TEST_SUITE_ID, copiedTestCaseId);
+        } catch { /* 削除済みまたはコンテキスト閉鎖 */ }
       }
     }
   });

--- a/e2e/tests/web/test-suites.spec.ts
+++ b/e2e/tests/web/test-suites.spec.ts
@@ -58,13 +58,13 @@ test.describe('テストスイートCRUD', () => {
     // 「作成」ボタンをクリック
     await page.getByRole('button', { name: '作成', exact: true }).click();
 
-    // テストスイート詳細ページへ遷移し、作成が確認できる
+    // テストスイート詳細ページに遷移するのを待つ（API応答に時間がかかる場合あり）
+    await expect(page).toHaveURL(/\/test-suites\/[^/]+$/, { timeout: 30000 });
+
+    // テストスイート名またはトーストメッセージが表示される
     await expect(
       page.getByText('テストスイートを作成しました').or(page.getByText(suiteName))
     ).toBeVisible({ timeout: 10000 });
-
-    // テストスイート詳細ページに遷移していることを確認
-    await expect(page).toHaveURL(/\/test-suites\/[^/]+$/);
   });
 });
 

--- a/e2e/tests/web/user-settings.spec.ts
+++ b/e2e/tests/web/user-settings.spec.ts
@@ -151,11 +151,12 @@ test.describe('APIトークン管理', () => {
     const tokenName = `E2E Revoke Token ${Date.now()}`;
     await apiClient.createApiToken({ name: tokenName });
 
-    // ページをリロード
+    // ページをリロードしてトークン一覧の読み込みを待つ
     await page.reload();
+    await page.waitForLoadState('networkidle');
 
     // 作成したトークンが表示される
-    await expect(page.getByText(tokenName)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(tokenName)).toBeVisible({ timeout: 15000 });
 
     // トークン行の構造: div > [div(info with tokenName), button(delete)]
     // トークン名を含む要素を見つけ、その隣にあるボタンを探す


### PR DESCRIPTION
Enhance end-to-end tests by modifying wait conditions to prevent timeouts, adding a method to retrieve user organizations, and improving cleanup processes. Introduce organization filter selection in project list tests and strengthen transition checks after creating test suites. Ensure proper waiting for token list loading in user settings tests.