### PR TITLE
Change navigation from dashboard to project list upon organization selection

### DIFF
--- a/apps/web/src/pages/Organizations.tsx
+++ b/apps/web/src/pages/Organizations.tsx
@@ -23,10 +23,10 @@ export function OrganizationsPage() {
     org.organization.name.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
-  // 組織を選択してダッシュボードに移動
+  // 組織を選択してプロジェクト一覧に移動
   const handleSelectOrganization = (organizationId: string) => {
     selectOrganization(organizationId);
-    navigate('/dashboard');
+    navigate('/projects');
   };
 
   // 復元確認モーダルを開く
@@ -135,9 +135,9 @@ export function OrganizationsPage() {
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
         onSuccess={(organizationId) => {
-          // 作成した組織を選択してダッシュボードに移動
+          // 作成した組織を選択してプロジェクト一覧に移動
           selectOrganization(organizationId);
-          navigate('/dashboard');
+          navigate('/projects');
         }}
       />
 

--- a/apps/web/src/pages/Projects.tsx
+++ b/apps/web/src/pages/Projects.tsx
@@ -17,7 +17,10 @@ export function ProjectsPage() {
   const { user } = useAuthStore();
   const { organizations } = useOrganizationStore();
   const [searchQuery, setSearchQuery] = useState('');
-  const [organizationFilter, setOrganizationFilter] = useState<OrganizationFilter>('personal');
+  const { selectedOrganizationId } = useOrganizationStore();
+  const [organizationFilter, setOrganizationFilter] = useState<OrganizationFilter>(
+    selectedOrganizationId ?? 'personal'
+  );
   const [includeDeleted, setIncludeDeleted] = useState(false);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 


### PR DESCRIPTION
Update the navigation flow to redirect users to the project list instead of the dashboard after selecting an organization. Adjustments made to ensure the selected organization is properly reflected in the project filter.