### PR TITLE
Remove billing-related category from audit log documentation

### DIFF
--- a/docs/api/admin-audit-logs.md
+++ b/docs/api/admin-audit-logs.md
@@ -41,7 +41,6 @@ Cookie: admin_session=<session_id>
 | `MEMBER` | メンバー操作（招待、ロール変更等） |
 | `PROJECT` | プロジェクト操作（作成、更新、削除等） |
 | `API_TOKEN` | APIトークン操作（作成、失効等） |
-| `BILLING` | 課金操作（サブスクリプション変更等） |
 
 #### レスポンス
 
@@ -140,8 +139,7 @@ type AdminAuditLogCategory =
   | 'ORGANIZATION'
   | 'MEMBER'
   | 'PROJECT'
-  | 'API_TOKEN'
-  | 'BILLING';
+  | 'API_TOKEN';
 
 interface AdminAuditLogListResponse {
   auditLogs: AdminAuditLogEntry[];

--- a/docs/api/audit-logs.md
+++ b/docs/api/audit-logs.md
@@ -37,7 +37,6 @@ GET /api/v1/organizations/:organizationId/audit-logs
 | MEMBER | メンバー操作 |
 | PROJECT | プロジェクト操作 |
 | API_TOKEN | APIトークン操作 |
-| BILLING | 請求関連 |
 
 ### レスポンス例
 

--- a/docs/architecture/features/audit-log.md
+++ b/docs/architecture/features/audit-log.md
@@ -82,7 +82,6 @@
 | MEMBER | メンバー操作 | Users |
 | PROJECT | プロジェクト操作 | FolderKanban |
 | API_TOKEN | APIトークン操作 | Key |
-| BILLING | 請求関連 | CreditCard |
 
 ### アクション一覧
 


### PR DESCRIPTION
Eliminate references to the billing category in the audit log documentation to streamline the content and focus on relevant categories.