### PR TITLE
ログイン失敗時にパスワード入力欄をクリア

### DIFF
--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -98,6 +98,7 @@ export function LoginPage() {
       }
       const message = err instanceof Error ? err.message : 'ログインに失敗しました';
       setError(message);
+      setPassword('');
       setIsSubmitting(false);
     }
   };

--- a/apps/web/src/pages/__tests__/Login.test.tsx
+++ b/apps/web/src/pages/__tests__/Login.test.tsx
@@ -252,6 +252,25 @@ describe('LoginPage', () => {
       });
     });
 
+    it('ログイン失敗後にパスワード入力欄がクリアされる', async () => {
+      mockAuthApi.login.mockRejectedValue(new Error('メールアドレスまたはパスワードが正しくありません'));
+
+      renderLoginPage();
+
+      const passwordInput = screen.getByLabelText('パスワード');
+      fireEvent.change(screen.getByLabelText('メールアドレス'), {
+        target: { value: 'test@example.com' },
+      });
+      fireEvent.change(passwordInput, {
+        target: { value: 'wrongpass' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+
+      await waitFor(() => {
+        expect(passwordInput).toHaveValue('');
+      });
+    });
+
     it('送信中はボタンがdisabledになる', async () => {
       // resolveしないPromiseで送信中状態を維持
       mockAuthApi.login.mockReturnValue(new Promise(() => {}));


### PR DESCRIPTION
## 概要

ログイン失敗時にパスワード入力欄をクリアする機能を追加し、そのテストを実装。



## 変更理由



ユーザーがログインに失敗した際、パスワード欄を自動的にクリアすることで、誤入力を防ぎ、ユーザー体験を向上させるため。



## 変更内容



- ログイン失敗時にパスワード入力欄をクリアする処理を追加

- パスワードクリアの動作を確認するテストを追加



## テスト方法



- [x] ビルドが通ること (`docker compose exec dev pnpm build`)

- [x] テストが通ること (`docker compose exec dev pnpm test`)

- [x] Lint エラーがないこと (`docker compose exec dev pnpm lint`)



## チェックリスト



- [x] コミットメッセージが [Conventional Commits](https://www.conventionalcommits.org/) に従っている

- [x] 必要に応じてドキュメントを更新した

- [x] 破壊的変更がある場合、その内容を記載した



## 関連 Issue


Closes #248