### PR TITLE
レビューコメントにターゲット名を付与

### DIFF
--- a/apps/api/src/__tests__/unit/review-comment-enrichment.test.ts
+++ b/apps/api/src/__tests__/unit/review-comment-enrichment.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Prismaモック
+const mockPrismaTestCase = vi.hoisted(() => ({
+  findMany: vi.fn(),
+}));
+
+const mockPrismaTestSuite = vi.hoisted(() => ({
+  findMany: vi.fn(),
+}));
+
+vi.mock('@agentest/db', () => ({
+  prisma: {
+    testCase: mockPrismaTestCase,
+    testSuite: mockPrismaTestSuite,
+  },
+}));
+
+import {
+  enrichCommentsWithTargetName,
+  enrichReviewWithTargetNames,
+} from '../../repositories/review-comment-enrichment.js';
+
+describe('enrichCommentsWithTargetName', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('空配列の場合はそのまま返す', async () => {
+    const result = await enrichCommentsWithTargetName([]);
+
+    expect(result).toEqual([]);
+    expect(mockPrismaTestCase.findMany).not.toHaveBeenCalled();
+    expect(mockPrismaTestSuite.findMany).not.toHaveBeenCalled();
+  });
+
+  it('targetType=CASEのコメントにテストケース名を付与する', async () => {
+    const comments = [
+      { id: 'c1', targetType: 'CASE', targetId: 'case-1', content: 'test' },
+      { id: 'c2', targetType: 'CASE', targetId: 'case-2', content: 'test2' },
+    ];
+    mockPrismaTestCase.findMany.mockResolvedValue([
+      { id: 'case-1', title: 'ログインテスト' },
+      { id: 'case-2', title: '登録テスト' },
+    ]);
+
+    const result = await enrichCommentsWithTargetName(comments);
+
+    expect(result).toEqual([
+      { id: 'c1', targetType: 'CASE', targetId: 'case-1', content: 'test', targetName: 'ログインテスト' },
+      { id: 'c2', targetType: 'CASE', targetId: 'case-2', content: 'test2', targetName: '登録テスト' },
+    ]);
+    expect(mockPrismaTestCase.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ['case-1', 'case-2'] } },
+      select: { id: true, title: true },
+    });
+  });
+
+  it('targetType=SUITEのコメントにテストスイート名を付与する', async () => {
+    const comments = [
+      { id: 'c1', targetType: 'SUITE', targetId: 'suite-1', content: 'test' },
+    ];
+    mockPrismaTestSuite.findMany.mockResolvedValue([
+      { id: 'suite-1', name: '認証スイート' },
+    ]);
+
+    const result = await enrichCommentsWithTargetName(comments);
+
+    expect(result).toEqual([
+      { id: 'c1', targetType: 'SUITE', targetId: 'suite-1', content: 'test', targetName: '認証スイート' },
+    ]);
+    expect(mockPrismaTestSuite.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ['suite-1'] } },
+      select: { id: true, name: true },
+    });
+  });
+
+  it('CASEとSUITEが混在する場合に両方バッチ取得する', async () => {
+    const comments = [
+      { id: 'c1', targetType: 'CASE', targetId: 'case-1', content: 'case comment' },
+      { id: 'c2', targetType: 'SUITE', targetId: 'suite-1', content: 'suite comment' },
+      { id: 'c3', targetType: 'CASE', targetId: 'case-2', content: 'another case' },
+    ];
+    mockPrismaTestCase.findMany.mockResolvedValue([
+      { id: 'case-1', title: 'テストA' },
+      { id: 'case-2', title: 'テストB' },
+    ]);
+    mockPrismaTestSuite.findMany.mockResolvedValue([
+      { id: 'suite-1', name: 'スイートA' },
+    ]);
+
+    const result = await enrichCommentsWithTargetName(comments);
+
+    expect(result[0].targetName).toBe('テストA');
+    expect(result[1].targetName).toBe('スイートA');
+    expect(result[2].targetName).toBe('テストB');
+  });
+
+  it('同一targetIdの重複を排除してバッチ取得する', async () => {
+    const comments = [
+      { id: 'c1', targetType: 'CASE', targetId: 'case-1', content: 'first' },
+      { id: 'c2', targetType: 'CASE', targetId: 'case-1', content: 'second' },
+    ];
+    mockPrismaTestCase.findMany.mockResolvedValue([
+      { id: 'case-1', title: 'ログインテスト' },
+    ]);
+
+    const result = await enrichCommentsWithTargetName(comments);
+
+    expect(result[0].targetName).toBe('ログインテスト');
+    expect(result[1].targetName).toBe('ログインテスト');
+    // 重複排除されたIDで呼ばれる
+    expect(mockPrismaTestCase.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ['case-1'] } },
+      select: { id: true, title: true },
+    });
+  });
+
+  it('削除済みターゲットにはnullを返す', async () => {
+    const comments = [
+      { id: 'c1', targetType: 'CASE', targetId: 'deleted-case', content: 'test' },
+    ];
+    // 削除済みで見つからない
+    mockPrismaTestCase.findMany.mockResolvedValue([]);
+
+    const result = await enrichCommentsWithTargetName(comments);
+
+    expect(result[0].targetName).toBeNull();
+  });
+
+  it('CASEのみの場合はtestSuiteクエリを発行しない', async () => {
+    const comments = [
+      { id: 'c1', targetType: 'CASE', targetId: 'case-1', content: 'test' },
+    ];
+    mockPrismaTestCase.findMany.mockResolvedValue([
+      { id: 'case-1', title: 'テスト' },
+    ]);
+
+    await enrichCommentsWithTargetName(comments);
+
+    expect(mockPrismaTestCase.findMany).toHaveBeenCalled();
+    expect(mockPrismaTestSuite.findMany).not.toHaveBeenCalled();
+  });
+
+  it('SUITEのみの場合はtestCaseクエリを発行しない', async () => {
+    const comments = [
+      { id: 'c1', targetType: 'SUITE', targetId: 'suite-1', content: 'test' },
+    ];
+    mockPrismaTestSuite.findMany.mockResolvedValue([
+      { id: 'suite-1', name: 'スイート' },
+    ]);
+
+    await enrichCommentsWithTargetName(comments);
+
+    expect(mockPrismaTestSuite.findMany).toHaveBeenCalled();
+    expect(mockPrismaTestCase.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('enrichReviewWithTargetNames', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('レビューオブジェクトのコメントにtargetNameを付与する', async () => {
+    const review = {
+      id: 'review-1',
+      comments: [
+        { id: 'c1', targetType: 'CASE', targetId: 'case-1', content: 'comment' },
+      ],
+    };
+    mockPrismaTestCase.findMany.mockResolvedValue([
+      { id: 'case-1', title: 'ログインテスト' },
+    ]);
+
+    const result = await enrichReviewWithTargetNames(review);
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('review-1');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result!.comments[0] as any).targetName).toBe('ログインテスト');
+  });
+
+  it('nullレビューの場合はnullを返す', async () => {
+    const result = await enrichReviewWithTargetNames(null);
+
+    expect(result).toBeNull();
+    expect(mockPrismaTestCase.findMany).not.toHaveBeenCalled();
+  });
+
+  it('レビューの他のフィールドは変更しない', async () => {
+    const review = {
+      id: 'review-1',
+      status: 'SUBMITTED',
+      verdict: 'APPROVED',
+      summary: 'サマリー',
+      comments: [],
+    };
+
+    const result = await enrichReviewWithTargetNames(review);
+
+    expect(result).toEqual({
+      id: 'review-1',
+      status: 'SUBMITTED',
+      verdict: 'APPROVED',
+      summary: 'サマリー',
+      comments: [],
+    });
+  });
+});

--- a/apps/api/src/__tests__/unit/review-comment.repository.test.ts
+++ b/apps/api/src/__tests__/unit/review-comment.repository.test.ts
@@ -25,6 +25,11 @@ vi.mock('@agentest/db', () => ({
   },
 }));
 
+// エンリッチメントをパススルーにモック（リポジトリ単体テストでは不要）
+vi.mock('../../repositories/review-comment-enrichment.js', () => ({
+  enrichCommentsWithTargetName: vi.fn((comments: unknown) => Promise.resolve(comments)),
+}));
+
 describe('ReviewCommentRepository', () => {
   let repository: ReviewCommentRepository;
 

--- a/apps/api/src/__tests__/unit/review-comment.service.test.ts
+++ b/apps/api/src/__tests__/unit/review-comment.service.test.ts
@@ -5,9 +5,11 @@ import { NotFoundError, AuthorizationError, BadRequestError } from '@agentest/sh
 const mockPrisma = vi.hoisted(() => ({
   testSuite: {
     findFirst: vi.fn(),
+    findMany: vi.fn(),
   },
   testCase: {
     findFirst: vi.fn(),
+    findMany: vi.fn(),
   },
   projectMember: {
     findUnique: vi.fn(),
@@ -67,6 +69,9 @@ describe('ReviewCommentService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     service = new ReviewCommentService();
+    // エンリッチメント用デフォルト（空配列を返す）
+    mockPrisma.testCase.findMany.mockResolvedValue([]);
+    mockPrisma.testSuite.findMany.mockResolvedValue([]);
   });
 
   describe('findById', () => {
@@ -87,7 +92,7 @@ describe('ReviewCommentService', () => {
 
       const result = await service.findById(TEST_COMMENT_ID);
 
-      expect(result).toEqual(mockComment);
+      expect(result).toEqual({ ...mockComment, targetName: null });
       expect(mockPrisma.reviewComment.findUnique).toHaveBeenCalledWith({
         where: { id: TEST_COMMENT_ID },
         include: expect.any(Object),
@@ -408,7 +413,9 @@ describe('ReviewCommentService', () => {
         offset: 0,
       });
 
-      expect(result.items).toEqual(mockComments);
+      expect(result.items).toEqual(
+        mockComments.map((c) => ({ ...c, targetName: null }))
+      );
       expect(result.total).toBe(2);
     });
 

--- a/apps/api/src/__tests__/unit/review.repository.test.ts
+++ b/apps/api/src/__tests__/unit/review.repository.test.ts
@@ -34,6 +34,12 @@ vi.mock('@agentest/db', () => ({
   },
 }));
 
+// エンリッチメントをパススルーにモック（リポジトリ単体テストでは不要）
+vi.mock('../../repositories/review-comment-enrichment.js', () => ({
+  enrichReviewWithTargetNames: vi.fn((review: unknown) => Promise.resolve(review)),
+  enrichCommentsWithTargetName: vi.fn((comments: unknown) => Promise.resolve(comments)),
+}));
+
 import { ReviewRepository } from '../../repositories/review.repository.js';
 
 // テスト用固定ID

--- a/apps/api/src/repositories/review-comment-enrichment.ts
+++ b/apps/api/src/repositories/review-comment-enrichment.ts
@@ -1,0 +1,75 @@
+import { prisma } from '@agentest/db';
+
+/**
+ * コメント配列にターゲット名（テストケース名/テストスイート名）を付与する
+ * N+1問題を回避するため、targetTypeごとにバッチ取得する
+ */
+export async function enrichCommentsWithTargetName<
+  T extends { targetType: string; targetId: string },
+>(comments: T[]): Promise<(T & { targetName: string | null })[]> {
+  if (comments.length === 0) {
+    return [];
+  }
+
+  // targetTypeごとにユニークなIDを収集
+  const caseIds = [
+    ...new Set(
+      comments
+        .filter((c) => c.targetType === 'CASE')
+        .map((c) => c.targetId)
+    ),
+  ];
+  const suiteIds = [
+    ...new Set(
+      comments
+        .filter((c) => c.targetType === 'SUITE')
+        .map((c) => c.targetId)
+    ),
+  ];
+
+  // バッチ取得（必要な場合のみクエリ発行、並列実行）
+  const [cases, suites] = await Promise.all([
+    caseIds.length > 0
+      ? prisma.testCase.findMany({
+          where: { id: { in: caseIds } },
+          select: { id: true, title: true },
+        })
+      : Promise.resolve([]),
+    suiteIds.length > 0
+      ? prisma.testSuite.findMany({
+          where: { id: { in: suiteIds } },
+          select: { id: true, name: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  // targetTypeプレフィックス付きMapでID衝突を回避
+  const nameMap = new Map<string, string>();
+  for (const tc of cases) {
+    nameMap.set(`CASE:${tc.id}`, tc.title);
+  }
+  for (const ts of suites) {
+    nameMap.set(`SUITE:${ts.id}`, ts.name);
+  }
+
+  // コメントにtargetNameをマッピング
+  return comments.map((comment) => ({
+    ...comment,
+    targetName: nameMap.get(`${comment.targetType}:${comment.targetId}`) ?? null,
+  }));
+}
+
+/**
+ * レビューオブジェクト全体のコメントにtargetNameを付与するラッパー
+ * null安全：nullが渡された場合はnullを返す
+ */
+export async function enrichReviewWithTargetNames<
+  T extends { comments: Array<{ targetType: string; targetId: string }> },
+>(review: T | null): Promise<T | null> {
+  if (!review) {
+    return null;
+  }
+
+  const enrichedComments = await enrichCommentsWithTargetName(review.comments);
+  return { ...review, comments: enrichedComments };
+}

--- a/apps/api/src/repositories/review-comment.repository.ts
+++ b/apps/api/src/repositories/review-comment.repository.ts
@@ -1,4 +1,5 @@
 import { prisma, type ReviewStatus, type ReviewTargetType, type ReviewTargetField, type Prisma } from '@agentest/db';
+import { enrichCommentsWithTargetName } from './review-comment-enrichment.js';
 
 /**
  * レビューコメント検索オプション
@@ -44,10 +45,13 @@ export class ReviewCommentRepository {
    * IDでレビューコメントを検索
    */
   async findById(id: string) {
-    return prisma.reviewComment.findUnique({
+    const comment = await prisma.reviewComment.findUnique({
       where: { id },
       include: commentInclude,
     });
+    if (!comment) return null;
+    const [enriched] = await enrichCommentsWithTargetName([comment]);
+    return enriched;
   }
 
   /**
@@ -77,7 +81,7 @@ export class ReviewCommentRepository {
     }
 
     // 検索実行
-    const [items, total] = await Promise.all([
+    const [rawItems, total] = await Promise.all([
       prisma.reviewComment.findMany({
         where,
         include: commentInclude,
@@ -88,6 +92,7 @@ export class ReviewCommentRepository {
       prisma.reviewComment.count({ where }),
     ]);
 
+    const items = await enrichCommentsWithTargetName(rawItems);
     return { items, total };
   }
 
@@ -105,7 +110,7 @@ export class ReviewCommentRepository {
     authorAgentSessionId?: string;
     content: string;
   }) {
-    return prisma.reviewComment.create({
+    const comment = await prisma.reviewComment.create({
       data: {
         reviewId: data.reviewId,
         targetType: data.targetType,
@@ -119,28 +124,34 @@ export class ReviewCommentRepository {
       },
       include: commentInclude,
     });
+    const [enriched] = await enrichCommentsWithTargetName([comment]);
+    return enriched;
   }
 
   /**
    * レビューコメントを更新
    */
   async update(id: string, data: { content: string }) {
-    return prisma.reviewComment.update({
+    const comment = await prisma.reviewComment.update({
       where: { id },
       data: { content: data.content },
       include: commentInclude,
     });
+    const [enriched] = await enrichCommentsWithTargetName([comment]);
+    return enriched;
   }
 
   /**
    * レビューコメントのステータスを更新
    */
   async updateStatus(id: string, status: ReviewStatus) {
-    return prisma.reviewComment.update({
+    const comment = await prisma.reviewComment.update({
       where: { id },
       data: { status },
       include: commentInclude,
     });
+    const [enriched] = await enrichCommentsWithTargetName([comment]);
+    return enriched;
   }
 
   /**

--- a/apps/api/src/repositories/review.repository.ts
+++ b/apps/api/src/repositories/review.repository.ts
@@ -5,6 +5,10 @@ import {
   type ReviewTargetField,
   type Prisma,
 } from '@agentest/db';
+import {
+  enrichReviewWithTargetNames,
+  enrichCommentsWithTargetName,
+} from './review-comment-enrichment.js';
 
 /**
  * レビュー検索オプション
@@ -75,10 +79,11 @@ export class ReviewRepository {
    * IDでレビューを検索
    */
   async findById(id: string) {
-    return prisma.review.findUnique({
+    const review = await prisma.review.findUnique({
       where: { id },
       include: reviewDetailInclude,
     });
+    return enrichReviewWithTargetNames(review);
   }
 
   /**
@@ -142,7 +147,7 @@ export class ReviewRepository {
    * 特定テストスイートに対するユーザーの下書きレビューを取得
    */
   async findDraftByUserAndTestSuite(userId: string, testSuiteId: string) {
-    return prisma.review.findFirst({
+    const review = await prisma.review.findFirst({
       where: {
         testSuiteId,
         authorUserId: userId,
@@ -150,6 +155,7 @@ export class ReviewRepository {
       },
       include: reviewDetailInclude,
     });
+    return enrichReviewWithTargetNames(review);
   }
 
   /**
@@ -161,7 +167,7 @@ export class ReviewRepository {
     authorAgentSessionId?: string;
     summary?: string;
   }) {
-    return prisma.review.create({
+    const review = await prisma.review.create({
       data: {
         testSuiteId: data.testSuiteId,
         authorUserId: data.authorUserId,
@@ -171,35 +177,38 @@ export class ReviewRepository {
       },
       include: reviewDetailInclude,
     });
+    return enrichReviewWithTargetNames(review) as Promise<typeof review>;
   }
 
   /**
    * レビューを更新
    */
   async update(id: string, data: { summary?: string }) {
-    return prisma.review.update({
+    const review = await prisma.review.update({
       where: { id },
       data: { summary: data.summary },
       include: reviewDetailInclude,
     });
+    return enrichReviewWithTargetNames(review) as Promise<typeof review>;
   }
 
   /**
    * 提出済みレビューの評価を更新
    */
   async updateVerdict(id: string, verdict: ReviewVerdict) {
-    return prisma.review.update({
+    const review = await prisma.review.update({
       where: { id },
       data: { verdict },
       include: reviewDetailInclude,
     });
+    return enrichReviewWithTargetNames(review) as Promise<typeof review>;
   }
 
   /**
    * レビューを提出（DRAFT → SUBMITTED）
    */
   async submit(id: string, data: { verdict: ReviewVerdict; summary?: string }) {
-    return prisma.review.update({
+    const review = await prisma.review.update({
       where: { id },
       data: {
         status: 'SUBMITTED',
@@ -209,6 +218,7 @@ export class ReviewRepository {
       },
       include: reviewDetailInclude,
     });
+    return enrichReviewWithTargetNames(review) as Promise<typeof review>;
   }
 
   /**
@@ -234,7 +244,7 @@ export class ReviewRepository {
     authorAgentSessionId?: string;
     content: string;
   }) {
-    return prisma.reviewComment.create({
+    const comment = await prisma.reviewComment.create({
       data: {
         reviewId: data.reviewId,
         targetType: data.targetType,
@@ -267,13 +277,15 @@ export class ReviewRepository {
         },
       },
     });
+    const [enriched] = await enrichCommentsWithTargetName([comment]);
+    return enriched;
   }
 
   /**
    * コメントをIDで検索
    */
   async findCommentById(id: string) {
-    return prisma.reviewComment.findUnique({
+    const comment = await prisma.reviewComment.findUnique({
       where: { id },
       include: {
         review: true,
@@ -296,13 +308,16 @@ export class ReviewRepository {
         },
       },
     });
+    if (!comment) return null;
+    const [enriched] = await enrichCommentsWithTargetName([comment]);
+    return enriched;
   }
 
   /**
    * コメントを更新
    */
   async updateComment(id: string, data: { content: string }) {
-    return prisma.reviewComment.update({
+    const comment = await prisma.reviewComment.update({
       where: { id },
       data: { content: data.content },
       include: {
@@ -325,13 +340,15 @@ export class ReviewRepository {
         },
       },
     });
+    const [enriched] = await enrichCommentsWithTargetName([comment]);
+    return enriched;
   }
 
   /**
    * コメントのステータスを更新
    */
   async updateCommentStatus(id: string, status: 'OPEN' | 'RESOLVED') {
-    return prisma.reviewComment.update({
+    const comment = await prisma.reviewComment.update({
       where: { id },
       data: { status },
       include: {
@@ -354,6 +371,8 @@ export class ReviewRepository {
         },
       },
     });
+    const [enriched] = await enrichCommentsWithTargetName([comment]);
+    return enriched;
   }
 
   /**

--- a/apps/web/src/components/review/ReviewCommentItem.tsx
+++ b/apps/web/src/components/review/ReviewCommentItem.tsx
@@ -189,6 +189,9 @@ export function ReviewCommentItem({
           <ReviewStatusBadge status={comment.status} showLabel={false} />
           <span className="text-xs text-foreground-muted truncate">
             {TARGET_FIELD_LABELS[comment.targetField]}
+            {comment.targetType === 'CASE' && comment.targetName && (
+              <> - {comment.targetName}</>
+            )}
           </span>
         </div>
         <div className="flex items-center gap-1">

--- a/apps/web/src/components/review/ReviewDetailContent.tsx
+++ b/apps/web/src/components/review/ReviewDetailContent.tsx
@@ -149,10 +149,13 @@ export function CommentCard({ comment }: CommentCardProps) {
     <div className="border border-border rounded-lg overflow-hidden">
       {/* ヘッダー */}
       <div className="flex items-center justify-between px-3 py-2 bg-background-secondary">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0">
           <ReviewStatusBadge status={comment.status} showLabel={false} />
-          <span className="text-xs text-foreground-muted">
+          <span className="text-xs text-foreground-muted truncate">
             {TARGET_FIELD_LABELS[comment.targetField]}
+            {comment.targetType === 'CASE' && comment.targetName && (
+              <> - {comment.targetName}</>
+            )}
           </span>
         </div>
       </div>
@@ -175,6 +178,13 @@ export function CommentCard({ comment }: CommentCardProps) {
             </span>
           </div>
         </div>
+
+        {/* 対象アイテムの原文スナップショット */}
+        {comment.targetItemContent && (
+          <div className="mb-3 p-2 bg-background-tertiary rounded border-l-2 border-accent">
+            <MarkdownPreview content={comment.targetItemContent} />
+          </div>
+        )}
 
         {/* コメント内容 */}
         <div className="text-sm">

--- a/packages/shared/src/types/review.ts
+++ b/packages/shared/src/types/review.ts
@@ -85,6 +85,7 @@ export interface ReviewCommentWithReplies extends ReviewComment {
   agentSession: ReviewAgentSession | null;
   replies: ReviewReply[];
   _count: { replies: number };
+  targetName: string | null;
 }
 
 /**


### PR DESCRIPTION
## 概要

レビューコメントにターゲット名を付与するエンリッチメント機能を追加し、関連するリポジトリおよびサービスのテストを更新。



## 変更理由



ターゲット名を付与することで、レビューコメントのコンテキストを明確にし、ユーザーの理解を助けるため。



## 変更内容



- ReviewCommentWithRepliesインターフェースにtargetNameを追加

- コメントエンリッチメント機能を実装

- コメント表示部分にターゲット名を表示するロジックを追加

- テストを更新し、エンリッチメント機能をモック



## テスト方法



- [x] ビルドが通ること (`docker compose exec dev pnpm build`)

- [x] テストが通ること (`docker compose exec dev pnpm test`)

- [x] Lint エラーがないこと (`docker compose exec dev pnpm lint`)



## チェックリスト



- [x] コミットメッセージが [Conventional Commits](https://www.conventionalcommits.org/) に従っている

- [x] 必要に応じてドキュメントを更新した

- [x] 破壊的変更がある場合、その内容を記載した
