### PR TITLE
e2e-runnerのスクリーンショットの保存パスを修正

### DIFF
--- a/.claude/agents/agentest-e2e-runner.md
+++ b/.claude/agents/agentest-e2e-runner.md
@@ -131,7 +131,7 @@ agent-browser fill @e2 "入力値"
 agent-browser scroll @e3 down
 
 # スクリーンショットを保存
-agent-browser screenshot /tmp/screenshot.png
+agent-browser screenshot tmp/screenshots/screenshot.png
 ```
 
 各ステップ実行後に記録：
@@ -149,7 +149,7 @@ agent-browser screenshot /tmp/screenshot.png
 
 ```bash
 # スクリーンショットを撮影
-agent-browser screenshot /tmp/evidence_{testCaseIndex}_{expectedResultIndex}.png
+agent-browser screenshot tmp/screenshots/evidence_{testCaseIndex}_{expectedResultIndex}.png
 
 # Step 1: presigned URL取得（構造化データが返される）
 upload_execution_evidence(executionId, expectedResultId, filePath, description)


### PR DESCRIPTION
## 概要

スクリーンショットの保存パスを修正し、ディレクトリ構造を整理しました。



## 変更理由



スクリーンショットの保存先を一貫性のあるディレクトリに変更することで、ファイル管理を容易にします。



## 変更内容



- スクリーンショットの保存パスを `/tmp/` から `tmp/screenshots/` に変更

- スクリーンショットのファイル名を整理
