### PR TITLE
テスト結果のタイトルの表示修正

### DIFF
--- a/apps/web/src/components/execution/ExecutionSidebar.tsx
+++ b/apps/web/src/components/execution/ExecutionSidebar.tsx
@@ -117,7 +117,7 @@ function TestCaseItem({
       />
 
       {/* タイトル */}
-      <span className="text-sm truncate flex-1">
+      <span className="text-sm truncate flex-1" title={testCase.title}>
         {testCase.title}
       </span>
 

--- a/apps/web/src/components/execution/ExecutionTestCaseDetailPanel.tsx
+++ b/apps/web/src/components/execution/ExecutionTestCaseDetailPanel.tsx
@@ -138,14 +138,14 @@ export function ExecutionTestCaseDetailPanel({
         <div className="flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-3 mb-2">
-              <h2 className="text-xl font-bold text-foreground truncate">
-                {testCase.title}
-              </h2>
               <span
                 className={`flex-shrink-0 px-2 py-0.5 text-xs font-medium rounded ${priorityColors[testCase.priority] || priorityColors.MEDIUM}`}
               >
                 {priorityLabels[testCase.priority] || testCase.priority}
               </span>
+              <h2 className="text-xl font-bold text-foreground truncate" title={testCase.title}>
+                {testCase.title}
+              </h2>
             </div>
             {testCase.description && (
               <MarkdownPreview content={testCase.description} className="text-sm text-foreground-muted" />

--- a/apps/web/src/components/execution/ExecutionTestCaseItem.tsx
+++ b/apps/web/src/components/execution/ExecutionTestCaseItem.tsx
@@ -121,16 +121,16 @@ export function ExecutionTestCaseItem({
           {index}
         </span>
 
-        {/* タイトル */}
-        <span className="flex-1 min-w-0 text-sm font-medium text-foreground truncate">
-          {testCase.title}
-        </span>
-
         {/* 優先度バッジ */}
         <span
           className={`flex-shrink-0 px-2 py-0.5 text-xs font-medium rounded ${priorityColors[testCase.priority] || priorityColors.MEDIUM}`}
         >
           {priorityLabels[testCase.priority] || testCase.priority}
+        </span>
+
+        {/* タイトル */}
+        <span className="flex-1 min-w-0 text-sm font-medium text-foreground truncate" title={testCase.title}>
+          {testCase.title}
         </span>
 
         {/* 進捗サマリー */}


### PR DESCRIPTION
## 概要

テストケースのタイトルにツールチップを追加しました。



## 変更理由



タイトルが長い場合に、ユーザーが内容を確認しやすくするためです。



## 変更内容



- テストケースタイトルにツールチップを追加しました。

- `ExecutionTestCaseDetailPanel`コンポーネントのタイトルにツールチップを追加しました。

- `ExecutionTestCaseItem`コンポーネントのタイトルにツールチップを追加しました。



## テスト方法



- [x] ビルドが通ること (`docker compose exec dev pnpm build`)

- [x] テストが通ること (`docker compose exec dev pnpm test`)

- [x] Lint エラーがないこと (`docker compose exec dev pnpm lint`)



## チェックリスト



- [x] コミットメッセージが [Conventional Commits](https://www.conventionalcommits.org/) に従っている

- [x] 必要に応じてドキュメントを更新した

- [x] 破壊的変更がある場合、その内容を記載した
