### PR TITLE
実行履歴アイテムに合格率ラベルを追加

### DIFF
--- a/apps/web/src/components/execution/ExecutionHistoryList.tsx
+++ b/apps/web/src/components/execution/ExecutionHistoryList.tsx
@@ -363,10 +363,14 @@ export function ExecutionHistoryList({ testSuiteId, projectId }: ExecutionHistor
 /**
  * 実行履歴アイテム
  */
-function ExecutionItem({ execution }: { execution: Execution }) {
+export function ExecutionItem({ execution }: { execution: Execution }) {
   // judgmentCountsから値を取得
   const counts = execution.judgmentCounts || { PASS: 0, FAIL: 0, PENDING: 0, SKIPPED: 0 };
   const total = counts.PASS + counts.FAIL + counts.PENDING + counts.SKIPPED;
+
+  // 合格率を計算（PENDING は除外）
+  const completedTotal = counts.PASS + counts.FAIL + counts.SKIPPED;
+  const passRate = completedTotal > 0 ? Math.round((counts.PASS / completedTotal) * 100) : 0;
 
   return (
     <Link
@@ -404,16 +408,23 @@ function ExecutionItem({ execution }: { execution: Execution }) {
         </span>
       </div>
 
-      {/* 期待結果の状況バー */}
+      {/* 期待結果の状況バー + 合格率ラベル */}
       {total > 0 && (
-        <div className="flex-1 min-w-0 max-w-48">
-          <ProgressBar
-            passed={counts.PASS}
-            failed={counts.FAIL}
-            skipped={counts.SKIPPED}
-            total={total}
-            size="sm"
-          />
+        <div className="flex items-center gap-2 flex-1 min-w-0 max-w-64">
+          <div className="flex-1 min-w-0">
+            <ProgressBar
+              passed={counts.PASS}
+              failed={counts.FAIL}
+              skipped={counts.SKIPPED}
+              total={total}
+              size="sm"
+            />
+          </div>
+          {completedTotal > 0 && (
+            <span className="text-xs text-foreground-muted font-code shrink-0" data-testid="pass-rate-label">
+              {counts.PASS}/{completedTotal} ({passRate}%)
+            </span>
+          )}
         </div>
       )}
 

--- a/apps/web/src/components/execution/__tests__/ExecutionHistoryList.test.tsx
+++ b/apps/web/src/components/execution/__tests__/ExecutionHistoryList.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { ExecutionItem } from '../ExecutionHistoryList';
+import type { Execution } from '../../../lib/api';
+
+// ProgressBar のモック
+vi.mock('../../ui/ProgressBar', () => ({
+  ProgressBar: () => <div data-testid="progress-bar" />,
+}));
+
+// date のモック
+vi.mock('../../../lib/date', () => ({
+  formatDateTime: () => '2024-01-01 00:00:00',
+  formatRelativeTime: () => '2日前',
+}));
+
+/**
+ * テスト用 Execution データを作成するヘルパー
+ */
+function createExecution(overrides: Partial<Execution> = {}): Execution {
+  return {
+    id: 'exec-1',
+    testSuiteId: 'suite-1',
+    environmentId: 'env-1',
+    createdAt: '2024-01-01T00:00:00Z',
+    executedByUser: { id: 'user-1', name: 'テスター', avatarUrl: null },
+    environment: { id: 'env-1', name: 'DEV' },
+    judgmentCounts: { PASS: 3, FAIL: 2, PENDING: 1, SKIPPED: 2 },
+    ...overrides,
+  };
+}
+
+/**
+ * MemoryRouter でラップしてレンダリングするヘルパー
+ */
+function renderItem(execution: Execution) {
+  return render(
+    <MemoryRouter>
+      <ExecutionItem execution={execution} />
+    </MemoryRouter>,
+  );
+}
+
+describe('ExecutionItem 合格率ラベル', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('PASS:3, FAIL:2, PENDING:1, SKIPPED:2 のとき "3/7 (43%)" を表示する', () => {
+    renderItem(createExecution());
+    const label = screen.getByTestId('pass-rate-label');
+    expect(label).toHaveTextContent('3/7 (43%)');
+  });
+
+  it('total === 0 のときラベルを表示しない', () => {
+    renderItem(
+      createExecution({
+        judgmentCounts: { PASS: 0, FAIL: 0, PENDING: 0, SKIPPED: 0 },
+      }),
+    );
+    expect(screen.queryByTestId('pass-rate-label')).toBeNull();
+  });
+
+  it('全件 PASS のとき "5/5 (100%)" を表示する', () => {
+    renderItem(
+      createExecution({
+        judgmentCounts: { PASS: 5, FAIL: 0, PENDING: 0, SKIPPED: 0 },
+      }),
+    );
+    expect(screen.getByTestId('pass-rate-label')).toHaveTextContent('5/5 (100%)');
+  });
+
+  it('全件 PENDING（completedTotal === 0）のときラベルを表示しない', () => {
+    renderItem(
+      createExecution({
+        judgmentCounts: { PASS: 0, FAIL: 0, PENDING: 5, SKIPPED: 0 },
+      }),
+    );
+    expect(screen.queryByTestId('pass-rate-label')).toBeNull();
+  });
+
+  it('全件 FAIL のとき "0/3 (0%)" を表示する', () => {
+    renderItem(
+      createExecution({
+        judgmentCounts: { PASS: 0, FAIL: 3, PENDING: 0, SKIPPED: 0 },
+      }),
+    );
+    expect(screen.getByTestId('pass-rate-label')).toHaveTextContent('0/3 (0%)');
+  });
+
+  it('judgmentCounts が undefined のときラベルを表示しない', () => {
+    renderItem(
+      createExecution({
+        judgmentCounts: undefined,
+      }),
+    );
+    expect(screen.queryByTestId('pass-rate-label')).toBeNull();
+  });
+
+  it('ラベルに font-code クラスが適用されている', () => {
+    renderItem(createExecution());
+    const label = screen.getByTestId('pass-rate-label');
+    expect(label.className).toContain('font-code');
+  });
+});

--- a/docs/architecture/features/test-execution.md
+++ b/docs/architecture/features/test-execution.md
@@ -177,6 +177,7 @@
   - 実行者
   - 環境名
   - 結果サマリー（PASS/FAIL/SKIPPED/PENDING）
+  - 合格率ラベル（`PASS数/完了数 (合格率%)`形式、PENDING除外で算出、completedTotal > 0 の場合のみ表示）
   - 詳細リンク
 - **フィルタリング**
   - 日付範囲（作成日基準）


### PR DESCRIPTION
## 概要

実行履歴アイテムに合格率ラベルを追加し、テストを実装。



## 変更理由



合格率を表示することで、テスト結果の理解を容易にするため。



## 変更内容



- 合格率を計算し、表示するラベルを追加。

- 合格率ラベルの表示に関するテストを実装。



## テスト方法



- [x] ビルドが通ること (`docker compose exec dev pnpm build`)

- [x] テストが通ること (`docker compose exec dev pnpm test`)

- [x] Lint エラーがないこと (`docker compose exec dev pnpm lint`)



## チェックリスト



- [x] コミットメッセージが [Conventional Commits](https://www.conventionalcommits.org/) に従っている

- [x] 必要に応じてドキュメントを更新した

- [x] 破壊的変更がある場合、その内容を記載した
