### PR TITLE
テストケース名にツールチップを追加し、長いタイトルにも対応するテストを実装

### DIFF
--- a/apps/web/src/components/test-suite/TestCaseSidebar.tsx
+++ b/apps/web/src/components/test-suite/TestCaseSidebar.tsx
@@ -176,7 +176,7 @@ function SortableTestCaseItem({
       )}
 
       {/* タイトル */}
-      <span className="text-sm truncate flex-1">
+      <span className="text-sm truncate flex-1" title={testCase.title}>
         {testCase.title}
       </span>
 

--- a/apps/web/src/components/test-suite/__tests__/TestCaseSidebar.test.tsx
+++ b/apps/web/src/components/test-suite/__tests__/TestCaseSidebar.test.tsx
@@ -399,6 +399,28 @@ describe('TestCaseSidebar', () => {
     });
   });
 
+  describe('テストケース名のツールチップ', () => {
+    it('テストケース名のspanにtitle属性が設定されている', () => {
+      renderWithProviders(<TestCaseSidebar {...defaultProps} />);
+
+      const loginTest = screen.getByText('ログインテスト');
+      expect(loginTest).toHaveAttribute('title', 'ログインテスト');
+    });
+
+    it('長いタイトルでもtitleに全文が含まれる', () => {
+      const longTitle = 'これはとても長いテストケース名で、サイドバーの幅では表示しきれないほどの長さがあります';
+      renderWithProviders(
+        <TestCaseSidebar
+          {...defaultProps}
+          testCases={[createTestCase({ id: 'tc-long', title: longTitle, orderKey: 'a' })]}
+        />
+      );
+
+      const testCaseSpan = screen.getByText(longTitle);
+      expect(testCaseSpan).toHaveAttribute('title', longTitle);
+    });
+  });
+
   describe('件数表示', () => {
     it('フッターに表示中のテストケース件数を表示する', () => {
       renderWithProviders(<TestCaseSidebar {...defaultProps} />);


### PR DESCRIPTION
## 概要

テストケース名にツールチップを追加し、長いタイトルに対応するテストを実装しました。

## 変更理由

テストケース名が長い場合に、サイドバーでタイトルが切れてしまう問題を解決するためです。

## 変更内容

- テストケース名のspanにtitle属性を追加
- 長いタイトルに対するテストケースを追加
- ツールチップが正しく表示されることを確認するテストを実装

## テスト方法

- [x] ビルドが通ること (`docker compose exec dev pnpm build`)
- [x] テストが通ること (`docker compose exec dev pnpm test`)
- [x] Lint エラーがないこと (`docker compose exec dev pnpm lint`)

## チェックリスト

- [x] コミットメッセージが [Conventional Commits](https://www.conventionalcommits.org/) に従っている
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合、その内容を記載した
