### PR TITLE
テストケースサイドバーとテストスイート行のスケルトンローディングコンポーネントを追加

### DIFF
--- a/apps/web/src/components/test-suite/TestCaseSidebar.tsx
+++ b/apps/web/src/components/test-suite/TestCaseSidebar.tsx
@@ -32,6 +32,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { testSuitesApi, testCasesApi, ApiError, type TestCase, type ProjectMemberRole } from '../../lib/api';
 import { toast } from '../../stores/toast';
+import { TestCaseSidebarSkeleton } from './TestCaseSidebarSkeleton';
 
 /** ステータスフィルタの種類 */
 export type TestCaseFilter = 'active' | 'draft' | 'archived' | 'deleted';
@@ -451,9 +452,7 @@ export function TestCaseSidebar({
       {/* テストケース一覧 */}
       <div className="flex-1 overflow-y-auto p-2">
         {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <Loader2 className="w-5 h-5 animate-spin text-foreground-muted" />
-          </div>
+          <TestCaseSidebarSkeleton count={5} />
         ) : filteredTestCases.length === 0 ? (
           <div className="text-center py-8">
             {isDeletedFilter ? (

--- a/apps/web/src/components/test-suite/TestCaseSidebarSkeleton.tsx
+++ b/apps/web/src/components/test-suite/TestCaseSidebarSkeleton.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from '../ui/Skeleton';
+
+interface TestCaseSidebarSkeletonProps {
+  /** 表示する件数 */
+  count?: number;
+}
+
+/**
+ * テストケースサイドバーのスケルトンローディング
+ * SortableTestCaseItemの形状を模倣したプレースホルダー
+ */
+export function TestCaseSidebarSkeleton({ count = 5 }: TestCaseSidebarSkeletonProps) {
+  return (
+    <div className="space-y-0.5">
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-2 px-2 py-1.5"
+          data-testid="test-case-sidebar-skeleton-item"
+        >
+          {/* 優先度ドット */}
+          <Skeleton variant="circular" className="w-2 h-2 flex-shrink-0" />
+          {/* テストケース名 */}
+          <Skeleton className="flex-1 h-4" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/test-suite/TestSuiteRowSkeleton.tsx
+++ b/apps/web/src/components/test-suite/TestSuiteRowSkeleton.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from '../ui/Skeleton';
+
+interface TestSuiteRowSkeletonProps {
+  /** 表示する行数 */
+  count?: number;
+}
+
+/**
+ * テストスイート一覧のスケルトンローディング
+ * TestSuiteRowの形状を模倣したプレースホルダー
+ */
+export function TestSuiteRowSkeleton({ count = 5 }: TestSuiteRowSkeletonProps) {
+  return (
+    <div className="divide-y divide-border">
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-3 p-4"
+          data-testid="test-suite-row-skeleton-item"
+        >
+          {/* アイコン */}
+          <Skeleton variant="rectangular" className="w-10 h-10 flex-shrink-0" />
+          {/* コンテンツ */}
+          <div className="flex-1 space-y-2">
+            <div className="flex items-center gap-2">
+              <Skeleton className="w-2/5 h-4" />
+              <Skeleton variant="rectangular" className="w-16 h-5" />
+            </div>
+            <Skeleton className="w-3/5 h-3" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/test-suite/__tests__/TestCaseSidebar.test.tsx
+++ b/apps/web/src/components/test-suite/__tests__/TestCaseSidebar.test.tsx
@@ -428,4 +428,13 @@ describe('TestCaseSidebar', () => {
       expect(screen.getByText('2 件')).toBeInTheDocument();
     });
   });
+
+  describe('ローディング表示', () => {
+    it('isLoading=trueでスケルトンが表示される', () => {
+      renderWithProviders(<TestCaseSidebar {...defaultProps} isLoading={true} />);
+
+      const skeletonItems = screen.getAllByTestId('test-case-sidebar-skeleton-item');
+      expect(skeletonItems.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/apps/web/src/components/test-suite/__tests__/TestCaseSidebarSkeleton.test.tsx
+++ b/apps/web/src/components/test-suite/__tests__/TestCaseSidebarSkeleton.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TestCaseSidebarSkeleton } from '../TestCaseSidebarSkeleton';
+
+describe('TestCaseSidebarSkeleton', () => {
+  it('デフォルトで5件表示される', () => {
+    render(<TestCaseSidebarSkeleton />);
+
+    const items = screen.getAllByTestId('test-case-sidebar-skeleton-item');
+    expect(items).toHaveLength(5);
+  });
+
+  it('count propsで件数を制御できる', () => {
+    render(<TestCaseSidebarSkeleton count={3} />);
+
+    const items = screen.getAllByTestId('test-case-sidebar-skeleton-item');
+    expect(items).toHaveLength(3);
+  });
+
+  it('各行にSkeleton要素（role="status"）が含まれる', () => {
+    render(<TestCaseSidebarSkeleton count={1} />);
+
+    const skeletons = screen.getAllByRole('status');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/test-suite/__tests__/TestSuiteRowSkeleton.test.tsx
+++ b/apps/web/src/components/test-suite/__tests__/TestSuiteRowSkeleton.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TestSuiteRowSkeleton } from '../TestSuiteRowSkeleton';
+
+describe('TestSuiteRowSkeleton', () => {
+  it('デフォルトで5行表示される', () => {
+    render(<TestSuiteRowSkeleton />);
+
+    const items = screen.getAllByTestId('test-suite-row-skeleton-item');
+    expect(items).toHaveLength(5);
+  });
+
+  it('count propsで行数を制御できる', () => {
+    render(<TestSuiteRowSkeleton count={3} />);
+
+    const items = screen.getAllByTestId('test-suite-row-skeleton-item');
+    expect(items).toHaveLength(3);
+  });
+
+  it('各行にSkeleton要素（role="status"）が含まれる', () => {
+    render(<TestSuiteRowSkeleton count={1} />);
+
+    const skeletons = screen.getAllByRole('status');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/pages/ProjectDetail.tsx
+++ b/apps/web/src/pages/ProjectDetail.tsx
@@ -13,6 +13,7 @@ import {
 import { projectsApi, usersApi, labelsApi, type Project, type TestSuite, type TestSuiteSearchParams, type ProjectMemberRole, type Label } from '../lib/api';
 import { TestSuiteSearchFilter } from '../components/test-suite/TestSuiteSearchFilter';
 import { ProgressBar } from '../components/ui/ProgressBar';
+import { TestSuiteRowSkeleton } from '../components/test-suite/TestSuiteRowSkeleton';
 import { useAuth } from '../hooks/useAuth';
 import { ProjectOverviewTab } from '../components/project/ProjectOverviewTab';
 import { ProjectSettingsTab, type SettingsSection } from '../components/project/ProjectSettingsTab';
@@ -320,9 +321,7 @@ function TestSuiteListContent({
       </div>
 
       {isLoadingSuites ? (
-        <div className="p-8 text-center text-foreground-muted">
-          読み込み中...
-        </div>
+        <TestSuiteRowSkeleton count={5} />
       ) : testSuites.length === 0 ? (
         <div className="p-8 text-center">
           <FileText className="w-12 h-12 text-foreground-subtle mx-auto mb-3" />

--- a/apps/web/src/pages/__tests__/ProjectDetail.test.tsx
+++ b/apps/web/src/pages/__tests__/ProjectDetail.test.tsx
@@ -219,3 +219,36 @@ describe('ProjectDetailPage - TestSuiteRow プログレスバー', () => {
     expect(await screen.findByText('100%')).toBeInTheDocument();
   });
 });
+
+describe('ProjectDetailPage - ローディング表示', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockedProjectsApi.getById.mockResolvedValue({
+      project: {
+        id: 'proj-1',
+        name: 'テストプロジェクト',
+        description: 'テスト用',
+        organizationId: null,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      },
+    });
+    mockedProjectsApi.getMembers.mockResolvedValue({
+      members: [{ id: 'member-1', projectId: 'proj-1', userId: 'user-1', role: 'OWNER', addedAt: '2024-01-01T00:00:00Z', user: mockUser }],
+    });
+    mockedUsersApi.getProjects.mockResolvedValue({ projects: [] });
+    mockedLabelsApi.getByProject.mockResolvedValue({ labels: [] });
+  });
+
+  it('テストスイート読み込み中にスケルトン行が表示される', async () => {
+    // searchTestSuitesを未解決Promiseにしてローディング状態を維持
+    mockedProjectsApi.searchTestSuites.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders();
+
+    // スケルトン行が表示されることを確認
+    const skeletonItems = await screen.findAllByTestId('test-suite-row-skeleton-item');
+    expect(skeletonItems.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 概要

テストケースサイドバーとテストスイート行のスケルトンローディングコンポーネントを追加し、プロジェクト詳細ページにローディング表示を統合。



## 変更理由



ユーザーがデータを読み込んでいる間、視覚的なフィードバックを提供するため。



## 変更内容



- テストケースサイドバーにスケルトンローディングコンポーネントを追加

- テストスイート行にスケルトンローディングコンポーネントを追加

- プロジェクト詳細ページにローディング表示を統合



## テスト方法



- [x] ビルドが通ること (`docker compose exec dev pnpm build`)

- [x] テストが通ること (`docker compose exec dev pnpm test`)

- [x] Lint エラーがないこと (`docker compose exec dev pnpm lint`)



## チェックリスト



- [x] コミットメッセージが [Conventional Commits](https://www.conventionalcommits.org/) に従っている

- [x] 必要に応じてドキュメントを更新した

- [x] 破壊的変更がある場合、その内容を記載した
