### PR TITLE
テスト実行履歴の合格率計算のロジックを修正

### DIFF
--- a/apps/web/src/components/execution/ExecutionHistoryList.tsx
+++ b/apps/web/src/components/execution/ExecutionHistoryList.tsx
@@ -368,9 +368,8 @@ export function ExecutionItem({ execution }: { execution: Execution }) {
   const counts = execution.judgmentCounts || { PASS: 0, FAIL: 0, PENDING: 0, SKIPPED: 0 };
   const total = counts.PASS + counts.FAIL + counts.PENDING + counts.SKIPPED;
 
-  // 合格率を計算（PENDING は除外）
-  const completedTotal = counts.PASS + counts.FAIL + counts.SKIPPED;
-  const passRate = completedTotal > 0 ? Math.round((counts.PASS / completedTotal) * 100) : 0;
+  // 合格率を計算（PENDING も分母に含める）
+  const passRate = total > 0 ? Math.round((counts.PASS / total) * 100) : 0;
 
   return (
     <Link
@@ -420,11 +419,9 @@ export function ExecutionItem({ execution }: { execution: Execution }) {
               size="sm"
             />
           </div>
-          {completedTotal > 0 && (
-            <span className="text-xs text-foreground-muted font-code shrink-0" data-testid="pass-rate-label">
-              {counts.PASS}/{completedTotal} ({passRate}%)
-            </span>
-          )}
+          <span className="text-xs text-foreground-muted font-code shrink-0" data-testid="pass-rate-label">
+            {counts.PASS}/{total} ({passRate}%)
+          </span>
         </div>
       )}
 

--- a/apps/web/src/components/execution/__tests__/ExecutionHistoryList.test.tsx
+++ b/apps/web/src/components/execution/__tests__/ExecutionHistoryList.test.tsx
@@ -47,10 +47,10 @@ describe('ExecutionItem 合格率ラベル', () => {
     vi.clearAllMocks();
   });
 
-  it('PASS:3, FAIL:2, PENDING:1, SKIPPED:2 のとき "3/7 (43%)" を表示する', () => {
+  it('PASS:3, FAIL:2, PENDING:1, SKIPPED:2 のとき "3/8 (38%)" を表示する', () => {
     renderItem(createExecution());
     const label = screen.getByTestId('pass-rate-label');
-    expect(label).toHaveTextContent('3/7 (43%)');
+    expect(label).toHaveTextContent('3/8 (38%)');
   });
 
   it('total === 0 のときラベルを表示しない', () => {
@@ -71,13 +71,13 @@ describe('ExecutionItem 合格率ラベル', () => {
     expect(screen.getByTestId('pass-rate-label')).toHaveTextContent('5/5 (100%)');
   });
 
-  it('全件 PENDING（completedTotal === 0）のときラベルを表示しない', () => {
+  it('全件 PENDING のとき "0/5 (0%)" を表示する', () => {
     renderItem(
       createExecution({
         judgmentCounts: { PASS: 0, FAIL: 0, PENDING: 5, SKIPPED: 0 },
       }),
     );
-    expect(screen.queryByTestId('pass-rate-label')).toBeNull();
+    expect(screen.getByTestId('pass-rate-label')).toHaveTextContent('0/5 (0%)');
   });
 
   it('全件 FAIL のとき "0/3 (0%)" を表示する', () => {

--- a/apps/web/src/pages/TestSuiteCases.tsx
+++ b/apps/web/src/pages/TestSuiteCases.tsx
@@ -555,8 +555,8 @@ export function OverviewTab({
               // judgmentCountsから値を取得
               const counts = execution.judgmentCounts || { PASS: 0, FAIL: 0, PENDING: 0, SKIPPED: 0 };
               const total = counts.PASS + counts.FAIL + counts.PENDING + counts.SKIPPED;
-              const completedTotal = counts.PASS + counts.FAIL + counts.SKIPPED;
-              const passRate = completedTotal > 0 ? Math.round((counts.PASS / completedTotal) * 100) : 0;
+              // 合格率を計算（PENDING も分母に含める）
+              const passRate = total > 0 ? Math.round((counts.PASS / total) * 100) : 0;
 
               return (
                 <Link
@@ -592,11 +592,9 @@ export function OverviewTab({
                             size="sm"
                           />
                         </div>
-                        {completedTotal > 0 && (
-                          <span className="text-xs text-foreground-muted font-code shrink-0" data-testid="pass-rate-label">
-                            {counts.PASS}/{completedTotal} ({passRate}%)
-                          </span>
-                        )}
+                        <span className="text-xs text-foreground-muted font-code shrink-0" data-testid="pass-rate-label">
+                          {counts.PASS}/{total} ({passRate}%)
+                        </span>
                       </div>
                     )}
                   </div>

--- a/apps/web/src/pages/__tests__/TestSuiteCasesOverviewTab.test.tsx
+++ b/apps/web/src/pages/__tests__/TestSuiteCasesOverviewTab.test.tsx
@@ -99,10 +99,10 @@ describe('OverviewTab 実行履歴サマリー', () => {
     expect(screen.queryByTestId('progress-bar')).toBeNull();
   });
 
-  it('合格率ラベル: PASS:3, FAIL:2, SKIPPED:2 → "3/7 (43%)"', () => {
+  it('合格率ラベル: PASS:3, FAIL:2, PENDING:1, SKIPPED:2 → "3/8 (38%)"', () => {
     renderOverviewTab([createExecution()]);
     const label = screen.getByTestId('pass-rate-label');
-    expect(label).toHaveTextContent('3/7 (43%)');
+    expect(label).toHaveTextContent('3/8 (38%)');
   });
 
   it('合格率ラベル: 全件PASS → "5/5 (100%)"', () => {
@@ -114,13 +114,13 @@ describe('OverviewTab 実行履歴サマリー', () => {
     expect(screen.getByTestId('pass-rate-label')).toHaveTextContent('5/5 (100%)');
   });
 
-  it('合格率ラベル: 全件PENDING → ラベル非表示', () => {
+  it('合格率ラベル: 全件PENDING → "0/5 (0%)"', () => {
     renderOverviewTab([
       createExecution({
         judgmentCounts: { PASS: 0, FAIL: 0, PENDING: 5, SKIPPED: 0 },
       }),
     ]);
-    expect(screen.queryByTestId('pass-rate-label')).toBeNull();
+    expect(screen.getByTestId('pass-rate-label')).toHaveTextContent('0/5 (0%)');
   });
 
   it('judgmentCounts が undefined → ProgressBar・ラベル非表示', () => {


### PR DESCRIPTION
## 概要

合格率計算のロジックを修正し、PENDINGを分母に含めるように変更。



## 変更理由



合格率の計算において、PENDINGを考慮することでより正確な結果を得るため。



## 変更内容



- 合格率計算のロジックを修正

- テストケースを更新して期待値を反映



## テスト方法



- [x] ビルドが通ること (`docker compose exec dev pnpm build`)

- [x] テストが通ること (`docker compose exec dev pnpm test`)

- [x] Lint エラーがないこと (`docker compose exec dev pnpm lint`)



## チェックリスト



- [x] コミットメッセージが [Conventional Commits](https://www.conventionalcommits.org/) に従っている

- [x] 必要に応じてドキュメントを更新した

- [x] 破壊的変更がある場合、その内容を記載した
